### PR TITLE
Update combine_data.py to read WRF-WVT results from netCDF

### DIFF
--- a/combine_data.py
+++ b/combine_data.py
@@ -46,9 +46,15 @@ def read_wam2layers(basedir, casename):
 
 
 def read_wrf_wvt(basedir, casename):
-    print(
-        "Skipping wrf_wvt data for {casename} as it is not available in gridded form."
-    )
+    """Read data from WRF-WVT"""
+    print(f"Loading WRF-WVT data for {casename}")
+
+    path = basedir / casename / "results WRF-WVT"
+    filename = casename+"Case_Final.nc"
+    ds = xr.open_dataset(path / filename)
+    ds.coords["lon"] = (ds.coords["lon"] + 180) % 360 - 180
+    ds = ds.sortby([ds.lon, ds.lat])
+    return ds["moisture_sources_grid"].rename("WRF-WVT")
 
 
 def read_uvigo(basedir, casename):
@@ -336,5 +342,6 @@ def read_data(basedir, casename):
             read_flexpart_xu(basedir, casename),
             read_flexpart_tatfancheng(basedir, casename),
             read_uvigo(basedir, casename),
+            read_wrf_wvt(basedir, casename)
         ]
     )


### PR DESCRIPTION
Now WRF-WVT results can are readed from netCDF files. This allows the same functions to be used in Functions.py as with the other methods, but requires the netCDF files which are in the "results WRF-WVT" folders since the beginning of this month (before, there were only CSV files). Observe that you may want to omit WRF-WVT results when representing gridded results.